### PR TITLE
Feature/컴포넌트정보동적모달창구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.9",
         "styled-reset": "^4.4.5",
+        "uuid": "^9.0.0",
         "wait-on": "^7.0.1"
       },
       "devDependencies": {
@@ -16817,6 +16818,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17889,16 +17898,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -18067,9 +18076,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.9",
     "styled-reset": "^4.4.5",
+    "uuid": "^9.0.0",
     "wait-on": "^7.0.1"
   },
   "scripts": {

--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -170,3 +170,9 @@ ipcMain.handle("npmStartButton", async (event, result) => {
 
   BrowserWindow.getFocusedWindow().webContents.send("send-fiberData", data);
 });
+
+// NOTE: uuid 확인용 콘솔
+ipcMain.on("send-node-data", (event, data) => {
+  console.log(data);
+  BrowserWindow.getFocusedWindow().webContents.send("get-node-data", data);
+});

--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -59,7 +59,6 @@ const quitApplication = () => {
 const handleErrorMessage = error => {
   const lines = error.split(os.EOL);
   let detail;
-  console.log(lines[0]);
 
   if (lines[lines.length - 1] === "") {
     lines.pop();
@@ -154,9 +153,7 @@ ipcMain.handle("npmStartButton", async (event, result) => {
 
   exec(
     `PORT=${portNumber} BROWSER=none npm start`,
-    {
-      cwd: fileInfo.filePath,
-    },
+    { cwd: fileInfo.filePath },
     (error, stdout, stderr) => {
       handleErrorMessage(stderr);
     },

--- a/public/Electron/preload.js
+++ b/public/Electron/preload.js
@@ -5,6 +5,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   sendNodeData: data => ipcRenderer.send("send-node-data", data),
   getNodeData: callback => ipcRenderer.on("get-node-data", callback),
   fiberData: callback => ipcRenderer.on("send-fiberData", callback),
-  commandData: inputValue => ipcRenderer.invoke("npmStartButton", inputValue),
+  commandData: () => ipcRenderer.invoke("npmStartButton"),
   sendFilePath: path => ipcRenderer.on("send-file-path", path),
 });

--- a/public/Electron/renderer.js
+++ b/public/Electron/renderer.js
@@ -26,10 +26,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
 document.addEventListener("DOMContentLoaded", async () => {
   const inputElement = await getElementByIdAsync("npmStartButton");
-  inputElement.addEventListener("click", async event => {
+  inputElement.addEventListener("click", async () => {
     try {
-      const inputValue = event.target.value;
-      await window.electronAPI.commandData(inputValue);
+      await window.electronAPI.commandData();
     } catch (error) {
       console.error(error);
     }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import D3Tree from "../components/D3tree";
 import GlobalStyles from "../styles/GlobalStyles.styles";
 
@@ -77,10 +77,13 @@ const Main = styled.main`
 function App() {
   const [hasPath, setHasPath] = useState(false);
   const [directoryPath, setDirectoryPath] = useState("");
-  window.electronAPI.sendFilePath((event, path) => {
-    setDirectoryPath(path);
-    return path ? setHasPath(true) : null;
-  });
+
+  useEffect(() => {
+    window.electronAPI.sendFilePath((event, path) => {
+      setDirectoryPath(path);
+      return path ? setHasPath(true) : null;
+    });
+  }, [hasPath]);
 
   return (
     <EntryWrapper>

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -83,7 +83,7 @@ function App() {
       setDirectoryPath(path);
       return path ? setHasPath(true) : null;
     });
-  }, [hasPath]);
+  });
 
   return (
     <EntryWrapper>

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -81,6 +81,7 @@ function App() {
   useEffect(() => {
     window.electronAPI.sendFilePath((event, path) => {
       setDirectoryPath(path);
+
       return path ? setHasPath(true) : null;
     });
   });

--- a/src/assets/mockTreeData.json
+++ b/src/assets/mockTreeData.json
@@ -2,28 +2,33 @@
   "name": "CompFirst",
   "props": ["props1", "props2"],
   "state": ["state1, state2"],
+  "uuid": "asd13rwef23rsdf",
   "children": [
     {
       "name": "CompSecret",
       "props": ["secret"],
       "state": ["state1"],
+      "uuid": "f23jkthsndgjkssd",
       "children": []
     },
     {
       "name": "CompSecond",
       "props": ["second"],
       "state": ["secondState"],
+      "uuid": "sfjkhwjekbgnmsd",
       "children": [
         {
           "name": "CompThird",
           "props": ["Third"],
           "state": ["thirdState"],
+          "uuid": "dfjknbwkjenmqsnslf",
           "children": []
         },
         {
           "name": "CompThird",
           "props": ["Thirdasdasd2"],
           "state": ["thirdState2"],
+          "uuid": "kjdshfjknweiuskdnjm",
           "children": []
         }
       ]

--- a/src/assets/mockTreeData.json
+++ b/src/assets/mockTreeData.json
@@ -5,25 +5,25 @@
   "children": [
     {
       "name": "CompSecret",
-      "props": [],
-      "state": [],
+      "props": ["secret"],
+      "state": ["state1"],
       "children": []
     },
     {
       "name": "CompSecond",
-      "props": [],
-      "state": [],
+      "props": ["second"],
+      "state": ["secondState"],
       "children": [
         {
           "name": "CompThird",
-          "props": [],
-          "state": [],
+          "props": ["Third"],
+          "state": ["thirdState"],
           "children": []
         },
         {
           "name": "CompThird",
-          "props": [],
-          "state": [],
+          "props": ["Thirdasdasd2"],
+          "state": ["thirdState2"],
           "children": []
         }
       ]

--- a/src/assets/mockTreeData.json
+++ b/src/assets/mockTreeData.json
@@ -27,7 +27,7 @@
         {
           "name": "CompThird",
           "props": ["Thirdasdasd2"],
-          "state": ["thirdState2"],
+          "state": ["thirdState2", "thirdState5"],
           "uuid": "kjdshfjknweiuskdnjm",
           "children": []
         }

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { hierarchy } from "d3";
+
 import Modal from "./Modal";
 import getTreeSVG from "../utils/getTreeSVG";
 import createNode from "../utils/reactFiberTree";

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -50,9 +50,9 @@ export default function D3Tree() {
 
     componentNodes.forEach(node => {
       node.addEventListener("mouseover", event => {
-        const nodeData = hierarchyData
-          .descendants()
-          .find(d => d.data.uuid === event.target.id);
+        const nodeData = hierarchyData.find(
+          d => d.data.uuid === event.target.id,
+        );
         if (nodeData) {
           setNodeId(nodeData.data.name);
           setNodeProps(nodeData.data.props.join(", "));

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -14,7 +14,6 @@ const Wrapper = styled.div`
 `;
 
 export default function D3Tree() {
-  const [treeData, setTreeData] = useState(mockTreeData);
   const [hierarchyData, hierarchySetData] = useState(hierarchy(mockTreeData));
   const fiberTree = new Node();
 
@@ -22,7 +21,6 @@ export default function D3Tree() {
     try {
       await window.electronAPI.fiberData((event, value) => {
         createNode(value, fiberTree);
-        setTreeData(fiberTree);
         hierarchySetData(hierarchy(fiberTree));
       });
     } catch (error) {
@@ -40,7 +38,7 @@ export default function D3Tree() {
   const [nodeState, setNodeState] = useState(null);
 
   useEffect(() => {
-    const chart = getTreeSVG(treeData, {
+    const chart = getTreeSVG(hierarchyData.data, {
       label: d => d.name,
     });
 
@@ -52,13 +50,13 @@ export default function D3Tree() {
 
     componentNodes.forEach(node => {
       node.addEventListener("mouseover", event => {
-        const nodeData = hierarchyData.find(
-          d => d.data.uuid === event.target.id,
-        );
+        const nodeData = hierarchyData
+          .descendants()
+          .find(d => d.data.uuid === event.target.id);
         if (nodeData) {
           setNodeId(nodeData.data.name);
-          setNodeProps(nodeData.data.props);
-          setNodeState(nodeData.data.state);
+          setNodeProps(nodeData.data.props.join(", "));
+          setNodeState(nodeData.data.state.join(", "));
         }
       });
       node.addEventListener("mousemove", event => {
@@ -71,7 +69,7 @@ export default function D3Tree() {
         setNodeState(null);
       });
     });
-  }, [treeData, hierarchyData]);
+  }, [hierarchyData]);
 
   return (
     <Wrapper>
@@ -79,8 +77,8 @@ export default function D3Tree() {
       <div className="modal">
         <Modal nodeId={nodeId}>
           <div>name: {nodeId}</div>
-          <div>props: {JSON.stringify(nodeProps)}</div>
-          <div>state: {JSON.stringify(nodeState)}</div>
+          <div>props: {nodeProps}</div>
+          <div>state: {nodeState}</div>
         </Modal>
       </div>
     </Wrapper>

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -15,15 +15,15 @@ const Wrapper = styled.div`
 
 export default function D3Tree() {
   const [treeData, setTreeData] = useState(mockTreeData);
-  const [data, setData] = useState(hierarchy(mockTreeData));
+  const [hierarchyData, hierarchySetData] = useState(hierarchy(mockTreeData));
   const fiberTree = new Node();
 
   const getTreeData = async function () {
     try {
-      window.electronAPI.fiberData((event, value) => {
+      await window.electronAPI.fiberData((event, value) => {
         createNode(value, fiberTree);
         setTreeData(fiberTree);
-        setData(hierarchy(fiberTree));
+        hierarchySetData(hierarchy(fiberTree));
       });
     } catch (error) {
       console.error(error);
@@ -52,9 +52,9 @@ export default function D3Tree() {
 
     componentNodes.forEach(node => {
       node.addEventListener("mouseover", event => {
-        const nodeData = data
-          .descendants()
-          .find(d => d.data.name === event.target.id);
+        const nodeData = hierarchyData.find(
+          d => d.data.uuid === event.target.id,
+        );
         if (nodeData) {
           setNodeId(nodeData.data.name);
           setNodeProps(nodeData.data.props);
@@ -66,12 +66,12 @@ export default function D3Tree() {
         modal.style.top = `${event.clientY - modal.clientHeight - 10}px`;
       });
       node.addEventListener("mouseout", () => {
-        setNodeId("");
+        setNodeId(null);
         setNodeProps(null);
         setNodeState(null);
       });
     });
-  }, [treeData, data]);
+  }, [treeData, hierarchyData]);
 
   return (
     <Wrapper>

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -1,9 +1,12 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable func-names */
+import { v4 as uuidv4 } from "uuid";
 
 function Node() {
   this.name = "";
   this.props = [];
   this.state = [];
+  this.uuid = uuidv4();
   this.children = [];
 }
 

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -1,4 +1,5 @@
 /* eslint-disable func-names */
+
 function Node() {
   this.name = "";
   this.props = [];

--- a/src/utils/getTreeSVG.js
+++ b/src/utils/getTreeSVG.js
@@ -7,7 +7,7 @@ export default function getTreeSVG(
     label,
     width = 800,
     height = 1000,
-    r = 40,
+    r = 10,
     padding = 1,
     fill = "#999",
     stroke = "#555",

--- a/src/utils/getTreeSVG.js
+++ b/src/utils/getTreeSVG.js
@@ -7,7 +7,7 @@ export default function getTreeSVG(
     label,
     width = 800,
     height = 1000,
-    r = 10,
+    r = 40,
     padding = 1,
     fill = "#999",
     stroke = "#555",
@@ -64,7 +64,7 @@ export default function getTreeSVG(
 
   node
     .append("circle")
-    .attr("id", d => d.data.name)
+    .attr("id", d => d.data.uuid)
     .attr("fill", d => (d.children ? stroke : fill))
     .attr("r", r);
 


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 가장 최신 브랜치를 pull했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
 - 시각화한 트리의 각 노드에 마우스를 호버링 할 때 나타나는 모달창 안에, 해당 props와 state정보를 동적으로 나타내는 기능을 구현하였습니다.
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/121784425/226153541-56986337-2243-44a5-9a63-1ac903cfa320.png">