### PR TITLE
Feature/트리구조 줌인줌아웃

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
-npm run pre-commit

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -109,9 +109,7 @@ function App() {
       </Nav>
       <Main>
         <div>렌더링 화면 구역</div>
-        <div>
-          <D3Tree />
-        </div>
+        <D3Tree />
       </Main>
     </EntryWrapper>
   );

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable import/no-named-as-default */
 /* eslint-disable func-names */
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useRef, useState } from "react";
@@ -10,6 +10,8 @@ import Node from "../utils/Node";
 import mockTreeData from "../assets/mockTreeData.json";
 
 const Wrapper = styled.div`
+  overflow: hidden;
+
   .modal {
     position: absolute;
   }

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -1,4 +1,5 @@
 /* eslint-disable func-names */
+/* eslint-disable no-underscore-dangle */
 function Node() {
   this.name = "";
   this.props = [];
@@ -26,6 +27,8 @@ Node.prototype.setName = function (node) {
     this.name = node.memoizedProps;
   } else if (node.tag === 8) {
     this.name = "React.StrictMode";
+  } else if (node.tag === 10) {
+    this.name = node.elementType._context.displayName;
   } else if (node.tag === 11) {
     this.name = node.elementType.target;
   } else if (node.tag === 15) {


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 가장 최신 브랜치를 pull했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 트리 구조에서 스크롤을 하면 줌인/줌아웃이 됩니다.
- 초기에 트리구조가 x방향 중앙에 보이게 하기 위해서 [viewBox 첫번째 인자를 `-width / 2`로 설정](https://github.com/Common-LPK/reactree-frontend/pull/17/files#diff-0f00ff7328f8fd3845fe7fc105ff6cc4b425df8643667a7e632db693f9cf0924R33)해놨습니다.
- 줌인 줌아웃할 때마다 viewBox값이 바뀌어야 트리 크기 변화가 부드럽게 보이기 때문에, [줌 함수](https://github.com/Common-LPK/reactree-frontend/compare/dev...feature/%ED%8A%B8%EB%A6%AC%EA%B5%AC%EC%A1%B0-%EC%A4%8C%EC%9D%B8%EC%A4%8C%EC%95%84%EC%9B%83?expand=1#diff-0f00ff7328f8fd3845fe7fc105ff6cc4b425df8643667a7e632db693f9cf0924R56)에서 기존 viewBox 값 바탕으로 새로운 viewBox값을 바꾸는 로직을 추가했습니다. 이 때, 기존의 viewBox값이 필요해서 전역에서 배열 `viewBox`를 선언했습니다.

## 추가 설명
- d3로 그리는 svg크기를 확인하기 위해서 [background 색깔을 회색으로 지정](https://github.com/Common-LPK/reactree-frontend/compare/dev...feature/%ED%8A%B8%EB%A6%AC%EA%B5%AC%EC%A1%B0-%EC%A4%8C%EC%9D%B8%EC%A4%8C%EC%95%84%EC%9B%83?expand=1#diff-0f00ff7328f8fd3845fe7fc105ff6cc4b425df8643667a7e632db693f9cf0924R45)해놨습니다. d3작업이 완료되면 background 색상을 지정하는 구문을 지워서 배경이 투명해지도록 하면 될 것 같습니다.
- 줌인 줌아웃후 마우스로 클릭후 드래그를 하면 일정 부분에서 트리 svg가 튕겨나가는 오류가 있습니다. 추후에 수정해야합니다.

## 비고
- 