### PR TITLE
Feature/트리구조 드래그

### DIFF
--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -171,8 +171,6 @@ ipcMain.handle("npmStartButton", async (event, result) => {
   BrowserWindow.getFocusedWindow().webContents.send("send-fiberData", data);
 });
 
-// NOTE: uuid 확인용 콘솔
 ipcMain.on("send-node-data", (event, data) => {
-  console.log(data);
   BrowserWindow.getFocusedWindow().webContents.send("get-node-data", data);
 });

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -31,9 +31,9 @@ Node.prototype.setName = function (node) {
     this.name = node.memoizedProps;
   } else if (node.tag === 8) {
     this.name = "React.StrictMode";
-  } else if (node.tag === 10) {
+  } else if (node.tag === 10 && node.elementType) {
     this.name = node.elementType._context.displayName;
-  } else if (node.tag === 11) {
+  } else if (node.tag === 11 && node.elementType) {
     this.name = node.elementType.target;
   } else if (node.tag === 15) {
     this.name = "SimpleMemoComponent";


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 가장 최신 브랜치를 pull했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 트리구조를 보여주는 `svg` element를 드래그 하면 커서 모양이 `grab` -> `grabbing`으로 바뀝니다.
- 드래그 중일 때 `svg`의 viewBox속성값을 계속 바꿔주면서 자연스럽게 마우스 커서를 따라서 트리가 이동하는 것처럼 보이게 했습니다. [코드](https://github.com/Common-LPK/reactree-frontend/compare/dev...feature/%ED%8A%B8%EB%A6%AC%EA%B5%AC%EC%A1%B0-%EB%93%9C%EB%9E%98%EA%B7%B8?expand=1#diff-0f00ff7328f8fd3845fe7fc105ff6cc4b425df8643667a7e632db693f9cf0924R59)
- `svg`에 zoom기능을 담당하는 함수를 호출합니다. 그런데 이 함수에서 `svg`보다 아래에 선언된 변수 `node`의 속성값을 변경시키는 구문이 있어서 이 함수를 `node`가 선언되고 나서 아래에 선언하는 것이 맞다는 생각이 들었습니다. 그래서 [svg zoom기능을 담당하는 함수를 아래쪽으로 옮겼습니다.](https://github.com/Common-LPK/reactree-frontend/compare/dev...feature/%ED%8A%B8%EB%A6%AC%EA%B5%AC%EC%A1%B0-%EB%93%9C%EB%9E%98%EA%B7%B8?expand=1#diff-0f00ff7328f8fd3845fe7fc105ff6cc4b425df8643667a7e632db693f9cf0924R107-R125)

## 추가 설명
- 드래그 후 줌인/줌아웃을 하면 트리 위치변화가 부자연스럽습니다. 두 기능 간의 충돌을 해결해야 합니다.
- `Node.js`수정 사항) `node.tag`가 10 또는 11일 때 `node.elementType`이 없는 경우가 있어서 조건문을 추가했습니다.

## 비고
- 