### PR TITLE
feat: redux추가 진행중 중간상황

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@electron/remote": "^2.0.9",
+        "@reduxjs/toolkit": "^1.9.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -18,7 +19,9 @@
         "electron": "^23.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.0.5",
         "react-scripts": "5.0.1",
+        "redux": "^4.2.1",
         "styled-components": "^5.3.9",
         "styled-reset": "^4.4.5",
         "uuid": "^9.0.0",
@@ -3294,6 +3297,29 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
+      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
+      "dependencies": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3909,6 +3935,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4130,6 +4165,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -15775,6 +15815,44 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
+    "node_modules/react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15972,6 +16050,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -16097,6 +16191,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -18041,6 +18140,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "public/Electron/main.js",
   "dependencies": {
     "@electron/remote": "^2.0.9",
+    "@reduxjs/toolkit": "^1.9.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -14,7 +15,9 @@
     "electron": "^23.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.5",
     "react-scripts": "5.0.1",
+    "redux": "^4.2.1",
     "styled-components": "^5.3.9",
     "styled-reset": "^4.4.5",
     "uuid": "^9.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
       content="Web site created using create-react-app"
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script src="./Electron/renderer.js" defer></script>
     <title>React App</title>
   </head>
 
   <body>
     <div id="root"></div>
-    <script src="./Electron/renderer.js"></script>
   </body>
 </html>

--- a/src/App/store.js
+++ b/src/App/store.js
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+import d3treeReducer from "../features/d3treeSlice";
+import pathReducer from "../features/pathSlice";
+
+const store = configureStore({
+  reducer: {
+    d3tree: d3treeReducer,
+    path: pathReducer,
+  },
+});
+
+export default store;

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/prop-types */
 import { useEffect, useRef, useState } from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { hierarchy } from "d3";
 
@@ -25,12 +26,9 @@ const Wrapper = styled.div`
   }
 `;
 
-export default function D3Tree({
-  pathWidth,
-  pathHeight,
-  layout,
-  setPathHeight,
-}) {
+export default function D3Tree() {
+  const { widthSpacing, heightSpacing, layoutWidth, layoutHeight } =
+    useSelector(state => state.d3tree);
   const [hierarchyData, setHierarchyData] = useState(hierarchy(mockTreeData));
   const fiberTree = new Node();
 
@@ -56,11 +54,10 @@ export default function D3Tree({
 
     const chart = getTreeSVG(hierarchyData.data, {
       label: d => d.name,
-      width: layout.width,
-      height: layout.height,
-      dxWidth: pathWidth,
-      dyHeight: pathHeight,
-      setDyHeigth: setPathHeight,
+      width: layoutWidth,
+      height: layoutHeight,
+      dxWidth: null,
+      dyHeight: null,
     });
 
     if (svg.current.firstChild) svg.current.removeChild(svg.current.firstChild);
@@ -93,7 +90,7 @@ export default function D3Tree({
         setNodeState(null);
       });
     });
-  }, [hierarchyData, pathWidth, pathHeight, layout]);
+  }, [hierarchyData, widthSpacing, heightSpacing]);
 
   return (
     <Wrapper>

--- a/src/features/d3treeSlice.js
+++ b/src/features/d3treeSlice.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  widthSpacing: 150,
+  heightSpacing: 250,
+  layoutWidth: 400,
+  layoutHeight: 850,
+};
+
+const d3treeSlice = createSlice({
+  name: "d3tree",
+  initialState,
+  reducers: {
+    setLayout(state, action) {
+      state.layoutWidth = action.payload.clientWidth;
+      state.layoutHeight = action.payload.clientHeight;
+    },
+    setWidthSpacing(state, action) {
+      state.widthSpacing = action.payload.width;
+    },
+    setHeightSpacing(state, action) {
+      state.heightSpacing = action.payload.height;
+    },
+  },
+});
+
+export const d3treeActions = d3treeSlice.actions;
+export default d3treeSlice.reducer;

--- a/src/features/pathSlice.js
+++ b/src/features/pathSlice.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  hasPath: false,
+  directoryPath: null,
+};
+
+const pathSlice = createSlice({
+  name: "path",
+  initialState,
+  reducers: {
+    checkPath(state) {
+      state.hasPath = true;
+    },
+    setDirectoryPath(state, action) {
+      state.directoryPath = action.payload.path;
+    },
+  },
+});
+
+export const pathActions = pathSlice.actions;
+export default pathSlice.reducer;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,20 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-underscore-dangle */
 import ReactDOM from "react-dom/client";
+import { Provider } from "react-redux";
 
+import store from "./App/store";
 import App from "./App/App";
 import deepCopy from "./utils/deepCopy";
 import createNode from "./utils/reactFiberTree";
 import Node from "./utils/Node";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+);
 
 // NOTE: 현재 작성중인 로직 확인용(정상배포 전 삭제 필요)
 const fiberRootNode = deepCopy(root._internalRoot);


### PR DESCRIPTION
## PR 전 확인사항
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- `state` 의 전역관리를 위해 `redux-toolkit` 패키지를 추가했습니다. (각자 dev branch 최신화 후 `npm install` 실행해주세요)
- 사용자 디렉토리 경로 로직에 관련된 `hasPath`, `directoryPath` 변수를 기존 `useState` 를 사용한 로컬 `state` 에서 `redux store` 로 변경했습니다. (`state.path`)
- `d3tree` 작업에 필요한 `widthSpacing` `heightSpacing` `layoutWidth` `layoutHeight` 변수를 기존 `useState` 를 사용한 로컬 `state` 에서 `redux store` 로 변경했습니다. (`state.d3tree`)
- `features` 디렉토리에 각 `reducer` 디렉토리 구성했습니다.
-  작업완료 전 중간상황 공유 내용입니다.

## 추가 설명
- 기존에 사용중이던 `state` 를 `redux` 로 변경작업을 진행한 것이므로 상세설명은 생략하겠습니다. (`state` 역할 및 업데이트방식은 기존과 동일합니다.)

## 비고
- 사이드바의 spacing 기능(`widthSpacing` `heightSpacing`)과 Tree의 Zoom (`viewBox`) 기능이 충돌 발생합니다. Tree 내부 Zoom 관련된 변수들도 `state` 처리 필요할 것 같습니다.