### PR TITLE
Feature/파일구조정리

### DIFF
--- a/public/Electron/ipc-handler.js
+++ b/public/Electron/ipc-handler.js
@@ -1,0 +1,67 @@
+const { ipcMain, BrowserWindow, BrowserView, dialog } = require("electron");
+const { exec } = require("child_process");
+const path = require("path");
+const waitOn = require("wait-on");
+const { fileInfo, portNumber, handleErrorMessage } = require("./utils");
+
+const registerIpcHandlers = () => {
+  ipcMain.handle("get-path", async () => {
+    try {
+      const { canceled, filePaths } = await dialog.showOpenDialog({
+        properties: ["openDirectory"],
+      });
+
+      if (!canceled && filePaths.length > 0) {
+        [fileInfo.filePath] = filePaths;
+
+        BrowserWindow.getFocusedWindow().webContents.send(
+          "send-file-path",
+          fileInfo.filePath,
+        );
+      }
+
+      return null;
+    } catch (error) {
+      return console.error(error);
+    }
+  });
+
+  ipcMain.handle("npmStartButton", async () => {
+    const view = new BrowserView();
+    BrowserWindow.getFocusedWindow().setBrowserView(view);
+    view.setBounds({
+      x: 20,
+      y: 184,
+      width: 480,
+      height: 672,
+    });
+    view.setBackgroundColor("#ffffff");
+
+    view.webContents.loadFile(path.join(__dirname, "../views/loading.html"));
+
+    exec(
+      `PORT=${portNumber} BROWSER=none npm start`,
+      { cwd: fileInfo.filePath },
+      (error, stdout, stderr) => {
+        handleErrorMessage(stderr);
+      },
+    );
+
+    await waitOn({ resources: [`http://localhost:${portNumber}`] });
+    view.webContents.loadURL(`http://localhost:${portNumber}`);
+
+    const JScodes = `
+      const data = document.querySelector("#root").getAttribute("key");
+      JSON.parse(data);
+    `;
+    const data = await view.webContents.executeJavaScript(JScodes, true);
+
+    BrowserWindow.getFocusedWindow().webContents.send("send-fiberData", data);
+  });
+
+  ipcMain.on("send-node-data", (event, data) => {
+    BrowserWindow.getFocusedWindow().webContents.send("get-node-data", data);
+  });
+};
+
+module.exports = { registerIpcHandlers };

--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -1,90 +1,7 @@
-/* eslint-disable no-unused-vars */
-const {
-  app,
-  BrowserWindow,
-  ipcMain,
-  BrowserView,
-  dialog,
-  globalShortcut,
-} = require("electron");
-const { exec, execSync } = require("child_process");
+const { app, BrowserWindow, globalShortcut } = require("electron");
 const path = require("path");
-const os = require("os");
-const waitOn = require("wait-on");
-
-const fileInfo = {
-  filePath: null,
-};
-
-const checkPortNumber = () => {
-  let defaultPort = 3000;
-
-  const stdout = execSync(
-    "netstat -anv | grep LISTEN | awk '{print $4}'",
-  ).toString();
-  const lines = stdout.split(os.EOL);
-
-  if (lines[lines.length - 1] === "") {
-    lines.pop();
-  }
-
-  lines.forEach((line, index) => {
-    lines[index] = line.slice(line.indexOf(".") + 1);
-  });
-
-  const portArray = lines
-    .filter(port => port > 999 && port < 10000)
-    .map(Number);
-  portArray.sort((a, b) => a - b);
-  portArray.forEach(port => {
-    if (port === defaultPort) defaultPort += 1;
-  });
-
-  return defaultPort;
-};
-
-const portNumber = checkPortNumber();
-
-const quitApplication = () => {
-  try {
-    execSync(
-      `lsof -i :${portNumber} | grep LISTEN | awk '{print $2}' | xargs kill`,
-    );
-    app.quit();
-  } catch (error) {
-    console.error("Failed to kill server process:", error);
-  }
-};
-
-const handleErrorMessage = error => {
-  const lines = error.split(os.EOL);
-  let detail;
-
-  if (lines[lines.length - 1] === "") {
-    lines.pop();
-  }
-
-  for (let i = 0; i < lines.length; i += 1) {
-    if (lines[i].includes("no such file")) {
-      detail = "올바르지 않은 폴더 경로입니다.";
-      break;
-    }
-
-    if (lines[i].includes("Cannot find module")) {
-      detail = "모듈정보를 찾을 수 없습니다.";
-      break;
-    }
-  }
-
-  if (detail) {
-    dialog.showMessageBox({
-      buttons: ["확인"],
-      title: "Error!",
-      message: "Error",
-      detail,
-    });
-  }
-};
+const { quitApplication } = require("./utils");
+const { registerIpcHandlers } = require("./ipc-handler");
 
 const createWindow = () => {
   const win = new BrowserWindow({
@@ -101,6 +18,7 @@ const createWindow = () => {
 
 app.whenReady().then(() => {
   createWindow();
+  registerIpcHandlers();
 
   if (process.platform === "darwin") {
     globalShortcut.register("Command+Q", () => {
@@ -113,62 +31,4 @@ app.whenReady().then(() => {
       createWindow();
     }
   });
-});
-
-ipcMain.handle("get-path", async () => {
-  try {
-    const { canceled, filePaths } = await dialog.showOpenDialog({
-      properties: ["openDirectory"],
-    });
-
-    if (!canceled && filePaths.length > 0) {
-      [fileInfo.filePath] = filePaths;
-
-      BrowserWindow.getFocusedWindow().webContents.send(
-        "send-file-path",
-        fileInfo.filePath,
-      );
-    }
-
-    return null;
-  } catch (error) {
-    return console.error(error);
-  }
-});
-
-ipcMain.handle("npmStartButton", async (event, result) => {
-  const view = new BrowserView();
-  BrowserWindow.getFocusedWindow().setBrowserView(view);
-  view.setBounds({
-    x: 20,
-    y: 184,
-    width: 480,
-    height: 672,
-  });
-  view.setBackgroundColor("#ffffff");
-
-  view.webContents.loadFile(path.join(__dirname, "../views/loading.html"));
-
-  exec(
-    `PORT=${portNumber} BROWSER=none npm start`,
-    { cwd: fileInfo.filePath },
-    (error, stdout, stderr) => {
-      handleErrorMessage(stderr);
-    },
-  );
-
-  await waitOn({ resources: [`http://localhost:${portNumber}`] });
-  view.webContents.loadURL(`http://localhost:${portNumber}`);
-
-  const JScodes = `
-    const data = document.querySelector("#root").getAttribute("key");
-    JSON.parse(data);
-  `;
-  const data = await view.webContents.executeJavaScript(JScodes, true);
-
-  BrowserWindow.getFocusedWindow().webContents.send("send-fiberData", data);
-});
-
-ipcMain.on("send-node-data", (event, data) => {
-  BrowserWindow.getFocusedWindow().webContents.send("get-node-data", data);
 });

--- a/public/Electron/utils.js
+++ b/public/Electron/utils.js
@@ -1,0 +1,84 @@
+const { execSync } = require("child_process");
+const os = require("os");
+const { dialog, app } = require("electron");
+
+const fileInfo = {
+  filePath: null,
+};
+
+const checkPortNumber = () => {
+  let defaultPort = 3000;
+
+  const stdout = execSync(
+    "netstat -anv | grep LISTEN | awk '{print $4}'",
+  ).toString();
+  const lines = stdout.split(os.EOL);
+
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  lines.forEach((line, index) => {
+    lines[index] = line.slice(line.indexOf(".") + 1);
+  });
+
+  const portArray = lines
+    .filter(port => port > 999 && port < 10000)
+    .map(Number);
+  portArray.sort((a, b) => a - b);
+  portArray.forEach(port => {
+    if (port === defaultPort) defaultPort += 1;
+  });
+
+  return defaultPort;
+};
+
+const portNumber = checkPortNumber();
+
+const quitApplication = () => {
+  try {
+    execSync(
+      `lsof -i :${portNumber} | grep LISTEN | awk '{print $2}' | xargs kill`,
+    );
+    app.quit();
+  } catch (error) {
+    console.error("Failed to kill server process:", error);
+  }
+};
+
+const handleErrorMessage = error => {
+  const lines = error.split(os.EOL);
+  let detail;
+
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].includes("no such file")) {
+      detail = "올바르지 않은 폴더 경로입니다.";
+      break;
+    }
+
+    if (lines[i].includes("Cannot find module")) {
+      detail = "모듈정보를 찾을 수 없습니다.";
+      break;
+    }
+  }
+
+  if (detail) {
+    dialog.showMessageBox({
+      buttons: ["확인"],
+      title: "Error!",
+      message: "Error",
+      detail,
+    });
+  }
+};
+
+module.exports = {
+  fileInfo,
+  portNumber,
+  quitApplication,
+  handleErrorMessage,
+};


### PR DESCRIPTION
## PR 전 확인사항
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
 - electron `main.js` 파일의 길이가 점점 늘어나 가독성이 떨어지는 관계로, `main.js` 파일을 `ipc-handler.js`, `utils.js`, `main.js` 3개의 파일로 분할하였습니다.

## 추가 설명
 - main directory를 따로 만들어서 원래 `main.js`를 구성하던 파일들을 정리해두려고 하였으나, electron의 경로문제로 directory에는 따로 정리해두지 못하였습니다. 이 부분은 다시 시도해보겠습니다.
