### PR TITLE
Feature/폴더선택이후로직수정

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DIRECTORY_PATH=test/basic-react-app

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/__tests__/E2E/E2E.spec.js
+++ b/__tests__/E2E/E2E.spec.js
@@ -38,14 +38,14 @@ test.describe("E2E Test", () => {
 
   test("폴더 선택 버튼을 누르면 실행할 경로를 선정할 수 있습니다.", async () => {
     await eph.stubDialog(electronApp, "showOpenDialog", {
-      filePaths: [`${os.homedir()}/Desktop/test1`],
+      filePaths: [`${os.homedir()}/Desktop/${process.env.DIRECTORY_PATH}`],
       canceled: false,
     });
 
     await window.getByTestId("path").click();
     const result = await eph.ipcMainInvokeHandler(electronApp, "get-path");
 
-    expect(result).toBe(`${os.homedir()}/Desktop/test1`);
+    expect(result).toBe(`${os.homedir()}/Desktop/${process.env.DIRECTORY_PATH}`);
   });
 
   test("시작 버튼을 누르면 화면에 사용자의 리액트 구조를 추출합니다.", async () => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron:serve": "concurrently -k \"cross-env PORT=3002 BROWSER=none npm start\" \"npm run electron:start\"",
     "electron:build": "",
     "electron:start": "wait-on tcp:3002 && electron .",
-    "pre-commit": "lint-staged && rm -rf .git/hooks && ln -s ../.husky .git/hooks"
+    "pre-commit": "rm -rf .git/hooks && ln -s ../.husky .git/hooks"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/public/Electron/ipc-handler.js
+++ b/public/Electron/ipc-handler.js
@@ -17,10 +17,9 @@ const registerIpcHandlers = () => {
       if (canceled) return new Error("open dialog failed");
 
       const filePath = filePaths[0];
-      const userHomeDir = os.homedir();
-      const homeDirectory = path.join(userHomeDir);
+      const userHomeDirectory = os.homedir();
       exec(
-        `ln -s ${homeDirectory}/Desktop/reactree-frontend/src/utils/reactree.js ${filePath}/src/reactree-symlink.js`,
+        `ln -s ${userHomeDirectory}/Desktop/reactree-frontend/src/utils/reactree.js ${filePath}/src/reactree-symlink.js`,
         (error, stdout, stderr) => {
           handleErrorMessage(stderr);
         },
@@ -74,7 +73,7 @@ const registerIpcHandlers = () => {
       await waitOn({ resources: [`http://localhost:${portNumber}`] });
       view.webContents.loadURL(`http://localhost:${portNumber}`);
 
-      await waitOn({ resources: [`${userHomeDir}/Downloads/data.json`] });
+      await waitOn({ resources: [`${userHomeDirectory}/Downloads/data.json`] });
 
       writeFileSync(`${filePath}/src/index.js`, originalUserIndexJScodes, {
         encoding: "utf8",
@@ -84,7 +83,7 @@ const registerIpcHandlers = () => {
       exec(`rm ${filePath}/src/reactree-symlink.js`);
 
       const fiberFile = readFileSync(
-        path.join(`${userHomeDir}/Downloads/data.json`),
+        path.join(`${userHomeDirectory}/Downloads/data.json`),
       );
       exec("rm data.json", { cwd: `${os.homedir()}/Downloads` });
 

--- a/public/Electron/preload.js
+++ b/public/Electron/preload.js
@@ -2,9 +2,8 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("electronAPI", {
   openFileDialog: () => ipcRenderer.invoke("get-path"),
+  sendFilePath: path => ipcRenderer.on("send-file-path", path),
   sendNodeData: data => ipcRenderer.send("send-node-data", data),
   getNodeData: callback => ipcRenderer.on("get-node-data", callback),
   fiberData: callback => ipcRenderer.on("send-fiberData", callback),
-  commandData: () => ipcRenderer.invoke("npmStartButton"),
-  sendFilePath: path => ipcRenderer.on("send-file-path", path),
 });

--- a/public/Electron/renderer.js
+++ b/public/Electron/renderer.js
@@ -24,15 +24,15 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 });
 
-document.addEventListener("DOMContentLoaded", async () => {
-  const inputElement = await getElementByIdAsync("npmStartButton");
-  inputElement.addEventListener("click", async () => {
-    try {
-      await window.electronAPI.commandData();
-    } catch (error) {
-      console.error(error);
-    }
-  });
-});
+// document.addEventListener("DOMContentLoaded", async () => {
+//   const inputElement = await getElementByIdAsync("npmStartButton");
+//   inputElement.addEventListener("click", async () => {
+//     try {
+//       await window.electronAPI.commandData();
+//     } catch (error) {
+//       console.error(error);
+//     }
+//   });
+// });
 
 exports.getElementByIdAsync = getElementByIdAsync;

--- a/public/Electron/renderer.js
+++ b/public/Electron/renderer.js
@@ -24,15 +24,4 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 });
 
-// document.addEventListener("DOMContentLoaded", async () => {
-//   const inputElement = await getElementByIdAsync("npmStartButton");
-//   inputElement.addEventListener("click", async () => {
-//     try {
-//       await window.electronAPI.commandData();
-//     } catch (error) {
-//       console.error(error);
-//     }
-//   });
-// });
-
 exports.getElementByIdAsync = getElementByIdAsync;

--- a/public/Electron/utils.js
+++ b/public/Electron/utils.js
@@ -2,10 +2,6 @@ const { execSync, exec } = require("child_process");
 const os = require("os");
 const { dialog, app } = require("electron");
 
-const fileInfo = {
-  filePath: null,
-};
-
 const checkPortNumber = () => {
   let defaultPort = 3000;
 
@@ -41,6 +37,7 @@ const quitApplication = () => {
     execSync(
       `lsof -i :${portNumber} | grep LISTEN | awk '{print $2}' | xargs kill`,
     );
+
     app.quit();
   } catch (error) {
     console.error("Failed to kill server process:", error);
@@ -82,9 +79,8 @@ const handleErrorMessage = sdterr => {
 };
 
 module.exports = {
-  fileInfo,
-  portNumber,
+  handleErrorMessage,
   checkPortNumber,
   quitApplication,
-  handleErrorMessage,
+  portNumber,
 };

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -156,17 +156,6 @@ function App() {
               {pathEllips}
             </Button>
           </div>
-          <div className="buttonBar">
-            <p>시작 버튼을 눌러주세요.</p>
-            <Button
-              id="npmStartButton"
-              type="text"
-              disabled={!directoryPath}
-              data-testid="start"
-            >
-              npm start
-            </Button>
-          </div>
         </div>
         <div className="sideBar">
           <div>

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -44,7 +44,7 @@ Node.prototype.addProps = function (node) {
   if (!node.memoizedProps) return;
 
   if (node.tag === 0 || node.tag === 1) {
-    this.props = Object.values(node.memoizedProps);
+    Object.values(node.memoizedProps).forEach(item => this.props.push(item));
   }
 };
 

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -6,6 +6,9 @@ const getCircularReplacer = (key, value) => {
   if (key === "elementType" && typeof value === "function")
     return { name: value.name };
 
+  if (key === "memoizedProps" && typeof value === "object" && value)
+    return value;
+
   if (typeof value === "object" && value !== null) {
     if (seen.has(value)) return undefined;
 

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -15,9 +15,9 @@ const getCircularReplacer = (key, value) => {
   return value;
 };
 
-const reactree = root => {
+const reactree = rootInternalRoot => {
   try {
-    const fiber = deepCopy(root);
+    const fiber = deepCopy(rootInternalRoot);
     const fiberJson = JSON.stringify(fiber.current, getCircularReplacer);
     const link = document.createElement("a");
     const jsonString = `data:text/json;charset=utf-8,${fiberJson}`;


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 작업 브랜치 생성 전에 local dev를 최신화했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 폴더 선택 버튼을 누르면 바로 사용자프로젝트 렌더링 화면을 띄우고, 트리를 보여줍니다.
- `appendFile`을 이용해서 `reactree`함수 실행 코드를 `index.js`에 자동으로 추가할 수 있습니다. 사용자가 수동으로 추가하지 않아도 됩니다.
- 한번 트리를 보여준 다음에 사용자코드에 있던 `reactree`실행문과 `reactree-symlink.js`, `data.json`파일은 바로 삭제합니다. 이렇게 하면 폴더 경로를 바꿀 때 새로운 화면과 트리가 렌더링될 수 있습니다.
- 순환참조 `key`를 삭제하는 과정에서 `props`가 누락되는 것을 발견했습니다. 그래서 누락되지 않도록 `reactree.js`의 `getCircularReplacer`함수에서 `props` 관련 조건문을 추가했습니다.

## 추가 설명
- `data.json`다운로드 받는 창을 안 나오게 하는 방법 or 사용자입력방지 or 사용자입력값 추적방법은 못 찾았습니다. `fs.writeFile`과 같은 방법을 쓰면 좋을텐데 node.js환경에서 실행되지 않기 때문에 불가능하다고 생각했습니다. 기한이 다 되어 PR올렸는데, 조금더 고민해보겠습니다.

## 비고
- 