### PR TITLE
Feature/에러처리및리팩토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
   "lint-staged": {
     "**/*.{js, jsx, html, css, json}": [
       "prettier --write .",
-      "eslint --fix .",
-      "git add ."
+      "eslint --fix ."
     ]
   }
 }

--- a/public/Electron/dialog.js
+++ b/public/Electron/dialog.js
@@ -1,0 +1,8 @@
+const { dialog } = require("electron");
+
+const createErrorDialog = content => {
+  const title = "에러 발생!";
+  dialog.showErrorBox(title, content);
+};
+
+module.exports = { createErrorDialog };

--- a/public/Electron/ipc-handler.js
+++ b/public/Electron/ipc-handler.js
@@ -24,10 +24,14 @@ const registerIpcHandlers = () => {
           `ln -s ${reactreePath}/Desktop/reactree-frontend/src/utils/reactree.js ${filePaths}/src/Symlink.js`,
           (error, stdout, stderr) => {
             const pathError = handleErrorMessage(stderr);
-            if (pathError) createErrorDialog(pathError);
+
+            if (pathError) {
+              createErrorDialog(pathError);
+            }
           },
         );
 
+        await waitOn({ resources: [`${filePaths}/src/Symlink.js`] });
         BrowserWindow.getFocusedWindow().webContents.send(
           "send-file-path",
           fileInfo.filePath,
@@ -36,7 +40,7 @@ const registerIpcHandlers = () => {
 
       return fileInfo.filePath;
     } catch (error) {
-      return createErrorDialog(error);
+      return undefined;
     }
   });
 
@@ -59,6 +63,7 @@ const registerIpcHandlers = () => {
       { cwd: fileInfo.filePath },
       (error, stdout, stderr) => {
         const portError = handleErrorMessage(stderr);
+
         if (portError) {
           view.webContents.loadFile(
             path.join(__dirname, "../views/errorPage.html"),

--- a/public/Electron/preload.js
+++ b/public/Electron/preload.js
@@ -2,9 +2,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("electronAPI", {
   openFileDialog: () => ipcRenderer.invoke("get-path"),
-  sendNodeData: data => ipcRenderer.send("send-node-data", data),
   getNodeData: callback => ipcRenderer.on("get-node-data", callback),
-  fiberData: callback => ipcRenderer.on("send-fiberData", callback),
   commandData: () => ipcRenderer.invoke("npmStartButton"),
   sendFilePath: path => ipcRenderer.on("send-file-path", path),
 });

--- a/public/Electron/utils.js
+++ b/public/Electron/utils.js
@@ -1,6 +1,6 @@
+const { app } = require("electron");
 const { execSync, exec } = require("child_process");
 const os = require("os");
-const { dialog, app } = require("electron");
 
 const fileInfo = {
   filePath: null,
@@ -71,14 +71,7 @@ const handleErrorMessage = sdterr => {
     }
   }
 
-  if (detail) {
-    dialog.showMessageBox({
-      buttons: ["확인"],
-      title: "Error!",
-      message: "Error",
-      detail,
-    });
-  }
+  return detail;
 };
 
 module.exports = {

--- a/public/views/errorPage.html
+++ b/public/views/errorPage.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Error</title>
+  </head>
+  <body>
+    <h1>올바르지 않은 접근입니다.</h1>
+  </body>
+</html>

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -96,6 +96,12 @@ const Main = styled.main`
   }
 `;
 
+const Description = styled.div`
+  display: ${props => (props.hasPath ? "none" : "block")};
+  text-align: center;
+  align-items: center;
+`;
+
 function App() {
   const dispatch = useDispatch();
   const { directoryPath } = useSelector(state => state.path);
@@ -181,6 +187,11 @@ function App() {
               aria-label="width"
             />
           </div>
+          <Description hasPath={directoryPath}>
+            폴더 경로를 선택하면 아래 예시와 같이
+            <br />
+            트리구조가 렌더링 됩니다.
+          </Description>
           <div>
             <div className="title">HEIGHT</div>
             <input


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 작업 브랜치 생성 전에 local dev를 최신화했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 에러메세지를 보여주는 다이얼로그를 생성하는 `createErrorDialog` 함수를 만들었습니다. 인자로 넘겨주는 문자열을 에러메세지로 표시합니다.
- 에러 발생시 에러 다이얼로그와 함께 에러페이지가 렌더링 됩니다.
- 트리구역 상단의 사이드바 사이에 예시용 문구가 표기됩니다. 예시용 문구는 폴더경로 선택시 사라집니다.

## 추가 설명
- 새로고침할 경우 데이터가 유실되는 것을 방지하고자 `localStorage` 를 적용하려 했으나 적용할 경우 `fiberNode` 에서는 보이지 않는 `child` 객체가 트리구조에 생성되는 문제가 있습니다. 실제 `fiberNode` 객체에서는 확인이 되지 않는 값이라 문제해결이 어려워 이부분은 제외하고 PR올립니다.
<img width="726" alt="스크린샷 2023-03-27 오전 12 42 59" src="https://user-images.githubusercontent.com/110829006/227822129-5d7681d7-06cc-4bb9-8535-98452924d482.png">

## 비고
- 