### PR TITLE
refactor: Electron-ipc 리팩토링

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DIRECTORY_PATH=test/basic-react-app

--- a/public/Electron/dialog.js
+++ b/public/Electron/dialog.js
@@ -1,8 +1,0 @@
-const { dialog } = require("electron");
-
-const createErrorDialog = content => {
-  const title = "에러 발생!";
-  dialog.showErrorBox(title, content);
-};
-
-module.exports = { createErrorDialog };

--- a/public/Electron/ipc-handler.js
+++ b/public/Electron/ipc-handler.js
@@ -1,113 +1,103 @@
-const { ipcMain, BrowserWindow, BrowserView, dialog } = require("electron");
+const { BrowserWindow, BrowserView, dialog } = require("electron");
 const { exec, execSync } = require("child_process");
 const path = require("path");
-const waitOn = require("wait-on");
 const os = require("os");
 const { readFileSync, writeFileSync, appendFileSync } = require("fs");
+const waitOn = require("wait-on");
 
-const { createErrorDialog } = require("./dialog");
-const { handleErrorMessage, portNumber } = require("./utils");
+const { getErrorMessage, portNumber, createErrorDialog } = require("./utils");
 
-const userHomeDirectory = os.homedir();
+const userHomePath = os.homedir();
 
-const registerIpcHandlers = () => {
-  ipcMain.handle("get-path", async () => {
-    const mainWindow = BrowserWindow.getFocusedWindow();
-    const view = new BrowserView();
-
-    mainWindow.setBrowserView(view);
-    view.setBounds({
-      x: 8,
-      y: 164,
-      width: 740,
-      height: 740,
-    });
-    view.setAutoResize({ width: true, height: true });
-
-    const { canceled, filePaths } = await dialog.showOpenDialog({
-      properties: ["openDirectory"],
-    });
-
-    if (canceled) {
-      view.webContents.loadFile(
-        path.join(__dirname, "../views/errorPage.html"),
-      );
-      view.setBackgroundColor("white");
-      createErrorDialog(
-        "서버 연결이 원활하지 않습니다. 잠시 후 다시 시도해주세요.",
-      );
-    }
-
-    const filePath = filePaths[0];
-    exec(
-      `ln -s ${userHomeDirectory}/Desktop/reactree-frontend/src/utils/reactree.js ${filePath}/src/reactree-symlink.js`,
-      (error, stdout, stderr) => {
-        const pathError = handleErrorMessage(stderr);
-
-        if (pathError) {
-          view.webContents.loadFile(
-            path.join(__dirname, "../views/errorPage.html"),
-          );
-          view.setBackgroundColor("white");
-          createErrorDialog(pathError);
-        }
-      },
-    );
-
-    const originalUserIndexJScodes = readFileSync(`${filePath}/src/index.js`, {
-      encoding: "utf8",
-    });
-    const JScodes = `
-      // eslint-disable-next-line import/first
-      import reactree from "./reactree-symlink";
-
-      setTimeout(() => {
-        reactree(root._internalRoot);
-      }, 0);
-    `;
-
-    appendFileSync(`${filePath}/src/index.js`, JScodes);
-    mainWindow.webContents.send("send-file-path", filePath);
-    view.webContents.loadFile(path.join(__dirname, "../views/loading.html"));
-    view.setBackgroundColor("white");
-
-    execSync(
-      `lsof -i :${portNumber} | grep LISTEN | awk '{print $2}' | xargs kill`,
-    );
-
-    exec(
-      `PORT=${portNumber} BROWSER=none npm start`,
-      { cwd: filePath },
-      (error, stdout, stderr) => {
-        const startError = handleErrorMessage(stderr);
-
-        if (startError) {
-          view.webContents.loadFile(
-            path.join(__dirname, "../views/errorPage.html"),
-          );
-          view.setBackgroundColor("white");
-          createErrorDialog(startError);
-        }
-      },
-    );
-
-    await waitOn({ resources: [`http://localhost:${portNumber}`] });
-    view.webContents.loadURL(`http://localhost:${portNumber}`);
-
-    await waitOn({ resources: [`${userHomeDirectory}/Downloads/data.json`] });
-    writeFileSync(`${filePath}/src/index.js`, originalUserIndexJScodes, {
-      encoding: "utf8",
-    });
-    exec(`rm ${filePath}/src/reactree-symlink.js`);
-
-    const fiberFile = readFileSync(
-      path.join(`${userHomeDirectory}/Downloads/data.json`),
-    );
-    exec("rm data.json", { cwd: `${os.homedir()}/Downloads` });
-    mainWindow.webContents.send("get-node-data", JSON.parse(fiberFile));
-
-    return filePath;
-  });
+const handleError = (view, message) => {
+  view.webContents.loadFile(path.join(__dirname, "../views/errorPage.html"));
+  view.setBackgroundColor("white");
+  createErrorDialog(message);
 };
 
-module.exports = { registerIpcHandlers };
+const openDialogHandler = async () => {
+  const mainWindow = BrowserWindow.getFocusedWindow();
+  const view = new BrowserView();
+  mainWindow.setBrowserView(view);
+  view.setBounds({
+    x: 8,
+    y: 164,
+    width: 740,
+    height: 740,
+  });
+  view.setAutoResize({ width: true, height: true });
+
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    properties: ["openDirectory"],
+  });
+
+  if (canceled)
+    return handleError(
+      view,
+      "서버 연결이 원활하지 않습니다. 잠시 후 다시 시도해주세요.",
+    );
+
+  const filePath = filePaths[0];
+
+  exec(
+    `ln -s ${userHomePath}/Desktop/reactree-frontend/src/utils/reactree.js ${filePath}/src/reactree-symlink.js`,
+    (error, stdout, stderr) => {
+      const pathError = getErrorMessage(stderr);
+
+      if (pathError) handleError(view, pathError);
+    },
+  );
+
+  const originUsersJS = readFileSync(`${filePath}/src/index.js`, {
+    encoding: "utf8",
+  });
+  const JScodes = `
+    // eslint-disable-next-line import/first
+    import reactree from "./reactree-symlink";
+
+    setTimeout(() => {
+      reactree(root._internalRoot);
+    }, 0);
+  `;
+
+  if (!originUsersJS.includes("import reactree from")) {
+    appendFileSync(`${filePath}/src/index.js`, JScodes);
+  }
+
+  mainWindow.webContents.send("path-to-react", filePath);
+  view.webContents.loadFile(path.join(__dirname, "../views/loading.html"));
+  view.setBackgroundColor("white");
+
+  execSync(
+    `lsof -i :${portNumber} | grep LISTEN | awk '{print $2}' | xargs kill`,
+  );
+
+  exec(
+    `PORT=${portNumber} BROWSER=none npm start`,
+    { cwd: filePath },
+    (error, stdout, stderr) => {
+      const startError = getErrorMessage(stderr);
+
+      if (startError) handleError(view, startError);
+    },
+  );
+
+  await waitOn({ resources: [`http://localhost:${portNumber}`] });
+  view.webContents.loadURL(`http://localhost:${portNumber}`);
+
+  await waitOn({ resources: [`${userHomePath}/Downloads/data.json`] });
+  const fiberFile = readFileSync(
+    path.join(`${userHomePath}/Downloads/data.json`),
+  );
+
+  mainWindow.webContents.send("node-to-react", JSON.parse(fiberFile));
+  writeFileSync(`${filePath}/src/index.js`, originUsersJS, {
+    encoding: "utf8",
+  });
+  exec(`rm ${filePath}/src/reactree-symlink.js`);
+  exec("rm data.json", { cwd: `${userHomePath}/Downloads` });
+
+  return undefined;
+};
+
+exports.openDialogHandler = openDialogHandler;

--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -1,8 +1,8 @@
-const { app, BrowserWindow, globalShortcut } = require("electron");
+const { app, BrowserWindow, ipcMain, globalShortcut } = require("electron");
 const path = require("path");
 
 const { quitApplication } = require("./utils");
-const { registerIpcHandlers } = require("./ipc-handler");
+const { openDialogHandler } = require("./ipc-handler");
 const { SIZE } = require("../../src/assets/constants");
 
 const createWindow = () => {
@@ -19,7 +19,7 @@ const createWindow = () => {
 
 app.whenReady().then(() => {
   createWindow();
-  registerIpcHandlers();
+  ipcMain.handle("open-dialog", openDialogHandler);
 
   if (process.platform === "darwin") {
     globalShortcut.register("Command+Q", quitApplication);

--- a/public/Electron/preload.js
+++ b/public/Electron/preload.js
@@ -1,7 +1,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("electronAPI", {
-  openFileDialog: () => ipcRenderer.invoke("get-path"),
-  getNodeData: callback => ipcRenderer.on("get-node-data", callback),
-  sendFilePath: path => ipcRenderer.on("send-file-path", path),
+  openDialog: () => ipcRenderer.invoke("open-dialog"),
+  getFilePath: callback => ipcRenderer.on("path-to-react", callback),
+  getNodeData: callback => ipcRenderer.on("node-to-react", callback),
 });

--- a/public/Electron/renderer.js
+++ b/public/Electron/renderer.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const buttonElement = await getElementByIdAsync("directoryButton");
   buttonElement.addEventListener("click", async () => {
     try {
-      await window.electronAPI.openFileDialog();
+      await window.electronAPI.openDialog();
     } catch (error) {
       console.error(error);
     }

--- a/public/Electron/utils.js
+++ b/public/Electron/utils.js
@@ -1,4 +1,4 @@
-const { app } = require("electron");
+const { app, dialog } = require("electron");
 const { execSync, exec } = require("child_process");
 const os = require("os");
 
@@ -44,7 +44,7 @@ const quitApplication = () => {
   }
 };
 
-const handleErrorMessage = sdterr => {
+const getErrorMessage = sdterr => {
   const lines = sdterr.split(os.EOL);
   let detail;
 
@@ -71,9 +71,14 @@ const handleErrorMessage = sdterr => {
   return detail;
 };
 
+const createErrorDialog = content => {
+  const title = "에러 발생!";
+  dialog.showErrorBox(title, content);
+};
+
 module.exports = {
-  handleErrorMessage,
-  checkPortNumber,
+  getErrorMessage,
   quitApplication,
+  createErrorDialog,
   portNumber,
 };

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -110,10 +110,8 @@ function App() {
   let pathEllips = directoryPath || "폴더 선택";
 
   useEffect(() => {
-    window.electronAPI.sendFilePath((event, path) => {
+    window.electronAPI.getFilePath((event, path) => {
       dispatch(pathActions.setDirectoryPath({ path }));
-
-      return path ? dispatch(pathActions.checkPath()) : null;
     });
   }, [directoryPath, dispatch]);
 


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 작업 브랜치 생성 전에 local dev를 최신화했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- `Electron`의 `ipc-handler.js` 리팩토링 했습니다.

## 추가 설명
- UI변경으로 버튼2개의 역할을 1개로 통합함에 따라 `ipc-handler.js` 의 핸들러함수 리팩토링했습니다. 함수, 변수명도 길이를 줄이고 명확하게 통일했습니다.
- 불필요한 `dialog.js` 파일을 삭제하고 `utils.js` 로 통합했습니다.
- `contextBridge` 의 함수명을 보다 명확하고 통일성있게 변경했습니다.
