### PR TITLE
Feature/모달수정및app컴포넌트분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5712,9 +5712,9 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.9.tgz",
-      "integrity": "sha512-dUxhiNzBLr6IqlZXz6e/rN2YQXlFgOei/Dxy+e3cyXTJ4txSUbGT2/fmnD6zd/75jDMeW5bDee+YXxlFKHoV0A=="
+      "version": "18.15.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
+      "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7636,9 +7636,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001469",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
-      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+      "version": "1.0.30001470",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
+      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
       "funding": [
         {
           "type": "opencollective",
@@ -9662,9 +9662,9 @@
       "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
     },
     "node_modules/dns-packet": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
-      "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
+      "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -9869,9 +9869,9 @@
       "integrity": "sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg=="
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "16.18.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.20.tgz",
-      "integrity": "sha512-9fH66vSJnF563exTu3y1g2IbDz1vCj01Lbqms97r8j0qzfFisT2biypSfybVv/eYrtTB74x9xQTdRU8RyMiRrg=="
+      "version": "16.18.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.21.tgz",
+      "integrity": "sha512-TassPGd0AEZWA10qcNnXnSNwHlLfSth8XwUaWc3gTSDmBz/rKb613Qw5qRf6o2fdRBrLbsgeC9PMZshobkuUqg=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -21147,9 +21147,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -2,8 +2,9 @@ import { useEffect, useRef, useLayoutEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 
-import { pathActions } from "../features/pathSlice";
 import { d3treeActions } from "../features/d3treeSlice";
+import DirectorySelection from "../components/DirectorySelection";
+import Slider from "../components/Slider";
 import D3Tree from "../components/D3tree";
 import GlobalStyles from "../styles/GlobalStyles.styles";
 import { COLORS, SIZE } from "../assets/constants";
@@ -29,93 +30,31 @@ const Nav = styled.nav`
   align-items: center;
   justify-content: space-between;
   margin-bottom: ${SIZE.PADDING}px;
-
-  .buttonSection {
-    width: 50%;
-    display: flex;
-    justify-content: space-evenly;
-
-    .buttonBar {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-
-      > p {
-        padding-bottom: ${SIZE.PADDING}px;
-      }
-    }
-  }
-
-  .sideBar {
-    width: 50%;
-    display: flex;
-    justify-content: space-evenly;
-
-    .title {
-      text-align: center;
-    }
-  }
-`;
-
-const Button = styled.button`
-  min-width: 250px;
-  height: 30px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: ${COLORS.WHITE};
-  color: ${COLORS.BUTTON};
-  border: 2px solid ${COLORS.BUTTON};
-  border-radius: 10px;
-  font-weight: 500;
-  transition: 0.3s all ease;
-
-  :hover {
-    cursor: pointer;
-    background-color: ${COLORS.BUTTON};
-    color: ${COLORS.WHITE};
-  }
 `;
 
 const Main = styled.main`
-  height: 85%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  height: 85%;
   background-color: ${COLORS.BACKGROUND};
 
   .viewLayout {
     width: 100%;
     height: 100%;
+    margin: 1px;
     background-color: ${COLORS.VIEW_BACKGROUND};
-    color: white;
     border: 2px solid ${COLORS.BORDER};
     border-radius: 10px;
-    margin: 1px;
+    color: white;
   }
-`;
-
-const Description = styled.div`
-  display: ${props => (props.hasPath ? "none" : "block")};
-  text-align: center;
-  align-items: center;
 `;
 
 function App() {
   const dispatch = useDispatch();
-  const { directoryPath } = useSelector(state => state.path);
   const { layoutWidth, layoutHeight } = useSelector(state => state.d3tree);
   const ref = useRef(null);
-  let pathEllips = directoryPath || "폴더 선택";
-
-  useEffect(() => {
-    window.electronAPI.sendFilePath((event, path) => {
-      dispatch(pathActions.setDirectoryPath({ path }));
-
-      return path ? dispatch(pathActions.checkPath()) : null;
-    });
-  }, [directoryPath, dispatch]);
 
   useLayoutEffect(() => {
     dispatch(
@@ -141,13 +80,6 @@ function App() {
     return () => window.addEventListener("resize", handleWindow);
   }, [layoutWidth, layoutHeight, dispatch]);
 
-  if (directoryPath) {
-    pathEllips =
-      directoryPath.length > 29
-        ? `...${directoryPath.slice(-29)}`
-        : directoryPath;
-  }
-
   return (
     <EntryWrapper>
       <GlobalStyles />
@@ -155,45 +87,8 @@ function App() {
         <h1>Reactree</h1>
       </Header>
       <Nav>
-        <div className="buttonSection">
-          <div className="buttonBar">
-            <p>프로젝트의 폴더를 선택해주세요.</p>
-            <Button id="directoryButton" data-testid="path">
-              {pathEllips}
-            </Button>
-          </div>
-        </div>
-        <div className="sideBar">
-          <div>
-            <div className="title">WIDTH</div>
-            <input
-              id="sliderX"
-              type="range"
-              className="rangeBar"
-              min="10"
-              max="600"
-              name="width"
-              aria-label="width"
-            />
-          </div>
-          <Description hasPath={directoryPath}>
-            폴더 경로를 선택하면 아래 예시와 같이
-            <br />
-            트리구조가 렌더링 됩니다.
-          </Description>
-          <div>
-            <div className="title">HEIGHT</div>
-            <input
-              id="sliderY"
-              type="range"
-              className="rangeBar"
-              min="50"
-              max="500"
-              name="height"
-              aria-label="height"
-            />
-          </div>
-        </div>
+        <DirectorySelection />
+        <Slider />
       </Nav>
       <Main>
         <div className="viewLayout render" />

--- a/src/assets/constants.js
+++ b/src/assets/constants.js
@@ -11,6 +11,7 @@ const SIZE = {
   PADDING: 8,
   WINDOW_WIDTH: 1500,
   WINDOW_HEIGHT: 920,
+  MODAL_WIDTH: 200,
 };
 
 exports.COLORS = COLORS;

--- a/src/assets/mockTreeData.json
+++ b/src/assets/mockTreeData.json
@@ -1,13 +1,15 @@
 {
   "name": "Component First",
   "props": ["props1", "props2"],
-  "state": ["state1, state2"],
+  "state": ["state1", "state2"],
+  "reduxState": [],
   "uuid": "asd13rwef23rsdf",
   "children": [
     {
       "name": "Component Secret",
       "props": ["secret"],
       "state": ["state1"],
+      "reduxState": [],
       "uuid": "f23jkthsndgjkssd",
       "children": []
     },
@@ -15,12 +17,14 @@
       "name": "Component Second",
       "props": ["second"],
       "state": ["secondState"],
+      "reduxState": [],
       "uuid": "sfjkhwjekbgnmsd",
       "children": [
         {
           "name": "Component Third",
           "props": ["Third"],
           "state": ["thirdState"],
+          "reduxState": [],
           "uuid": "dfjknbwkjenmqsnslf",
           "children": []
         },
@@ -28,6 +32,7 @@
           "name": "Component Third",
           "props": ["Thirdasdasd2"],
           "state": ["thirdState2", "thirdState5"],
+          "reduxState": [],
           "uuid": "kjdshfjknweiuskdnjm",
           "children": []
         }

--- a/src/assets/mockTreeData.json
+++ b/src/assets/mockTreeData.json
@@ -1,31 +1,31 @@
 {
-  "name": "CompFirst",
+  "name": "Component First",
   "props": ["props1", "props2"],
   "state": ["state1, state2"],
   "uuid": "asd13rwef23rsdf",
   "children": [
     {
-      "name": "{_context}",
+      "name": "Component Secret",
       "props": ["secret"],
       "state": ["state1"],
       "uuid": "f23jkthsndgjkssd",
       "children": []
     },
     {
-      "name": "CompSecond",
+      "name": "Component Second",
       "props": ["second"],
       "state": ["secondState"],
       "uuid": "sfjkhwjekbgnmsd",
       "children": [
         {
-          "name": "CompThird",
+          "name": "Component Third",
           "props": ["Third"],
           "state": ["thirdState"],
           "uuid": "dfjknbwkjenmqsnslf",
           "children": []
         },
         {
-          "name": "CompThird",
+          "name": "Component Third",
           "props": ["Thirdasdasd2"],
           "state": ["thirdState2", "thirdState5"],
           "uuid": "kjdshfjknweiuskdnjm",

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -63,6 +63,7 @@ export default function D3Tree() {
   const [nodeName, setNodeName] = useState("");
   const [nodeProps, setNodeProps] = useState(null);
   const [nodeState, setNodeState] = useState(null);
+  const [nodeReduxState, setNodeReduxState] = useState(null);
 
   useEffect(() => {
     getTreeData();
@@ -89,6 +90,7 @@ export default function D3Tree() {
         setNodeId(nodeData.data.uuid);
         setNodeProps(nodeData.data.props.join(",\n"));
         setNodeState(nodeData.data.state.join(",\n"));
+        setNodeReduxState(nodeData.data.reduxState.join(",\n"));
       }
     });
     svgElement.addEventListener("mousemove", event => {
@@ -117,16 +119,20 @@ export default function D3Tree() {
       <div className="modal">
         <Modal nodeId={nodeId}>
           <div className="info-row">
-            <span className="title">name : </span>
+            <span className="title">Name : </span>
             <span className="description">{nodeName || "-"}</span>
           </div>
           <div className="info-row">
-            <span className="title">props : </span>
+            <span className="title">Props : </span>
             <pre className="description">{nodeProps || "-"}</pre>
           </div>
           <div className="info-row">
-            <span className="title">state : </span>
+            <span className="title">Local state : </span>
             <pre className="description">{nodeState || "-"}</pre>
+          </div>
+          <div className="info-row">
+            <span className="title">Redux state : </span>
+            <pre className="description">{nodeReduxState || "-"}</pre>
           </div>
         </Modal>
       </div>

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
   overflow: hidden;
 
   .svg {
-    height: 100%;
+    height: 90%;
   }
 
   .modal {
@@ -66,6 +66,7 @@ export default function D3Tree() {
   const [nodeProps, setNodeProps] = useState(null);
   const [nodeState, setNodeState] = useState(null);
   const [nodeReduxState, setNodeReduxState] = useState(null);
+  const [nodeFile, setNodeFile] = useState(null);
 
   useEffect(() => {
     getTreeData();
@@ -110,6 +111,14 @@ export default function D3Tree() {
     svgElement.addEventListener("mouseout", () => {
       setNodeId(null);
     });
+    svgElement.addEventListener("click", event => {
+      if (event.target.tagName === "circle") {
+        const nodeData = hierarchyData.find(
+          d => d.data.uuid === event.target.id,
+        );
+        setNodeFile(nodeData.data.file);
+      }
+    });
   }, [hierarchyData, layoutWidth, layoutHeight]);
 
   return (
@@ -135,6 +144,7 @@ export default function D3Tree() {
           </div>
         </Modal>
       </div>
+      <div>path: {nodeFile?.fileName}</div>
     </Wrapper>
   );
 }

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -119,7 +119,7 @@ export default function D3Tree() {
         <Modal nodeId={nodeId}>
           <div className="info-row">
             <span className="title">Name </span>
-            <span className="description">{nodeName || "-"}</span>
+            <pre className="description">{nodeName || "-"}</pre>
           </div>
           <div className="info-row">
             <span className="title">Props </span>

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -9,7 +9,7 @@ import getTreeSVG from "../utils/getTreeSVG";
 import createNode from "../utils/reactFiberTree";
 import Node from "../utils/Node";
 import mockTreeData from "../assets/mockTreeData.json";
-import { COLORS } from "../assets/constants";
+import { COLORS, SIZE } from "../assets/constants";
 
 const Wrapper = styled.div`
   height: 100%;
@@ -83,17 +83,24 @@ export default function D3Tree() {
 
       if (nodeData) {
         setNodeName(nodeData.data.name);
-        setNodeId(nodeData.data.uuid);
-
         if (typeof nodeData.data.name === "object") setNodeName("-");
 
+        setNodeId(nodeData.data.uuid);
         setNodeProps(nodeData.data.props.join(", "));
         setNodeState(nodeData.data.state.join(", "));
       }
     });
     svgElement.addEventListener("mousemove", event => {
-      modal.style.left = `${event.clientX + 10}px`;
-      modal.style.top = `${event.clientY - modal.clientHeight - 10}px`;
+      const isMouseCloseToRight =
+        window.innerWidth - event.clientX < SIZE.MODAL_WIDTH + SIZE.PADDING;
+
+      if (isMouseCloseToRight) {
+        modal.style.left = `${event.clientX - 10 - SIZE.MODAL_WIDTH}px`;
+        modal.style.top = `${event.clientY - modal.clientHeight - 10}px`;
+      } else {
+        modal.style.left = `${event.clientX + 10}px`;
+        modal.style.top = `${event.clientY - modal.clientHeight - 10}px`;
+      }
     });
     svgElement.addEventListener("mouseout", () => {
       setNodeId(null);

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -27,6 +27,8 @@ const Wrapper = styled.div`
   .modal .info-row {
     display: flex;
     margin: 5px 0;
+    padding: 3px;
+    box-shadow: 0px 1px 5px 1px rgba(0, 0, 0, 0.2);
 
     .title {
       width: 60px;
@@ -107,9 +109,6 @@ export default function D3Tree() {
     });
     svgElement.addEventListener("mouseout", () => {
       setNodeId(null);
-      setNodeName(null);
-      setNodeProps(null);
-      setNodeState(null);
     });
   }, [hierarchyData, layoutWidth, layoutHeight]);
 
@@ -119,19 +118,19 @@ export default function D3Tree() {
       <div className="modal">
         <Modal nodeId={nodeId}>
           <div className="info-row">
-            <span className="title">Name : </span>
+            <span className="title">Name </span>
             <span className="description">{nodeName || "-"}</span>
           </div>
           <div className="info-row">
-            <span className="title">Props : </span>
+            <span className="title">Props </span>
             <pre className="description">{nodeProps || "-"}</pre>
           </div>
           <div className="info-row">
-            <span className="title">Local state : </span>
+            <span className="title">Local state </span>
             <pre className="description">{nodeState || "-"}</pre>
           </div>
           <div className="info-row">
-            <span className="title">Redux state : </span>
+            <span className="title">Redux state </span>
             <pre className="description">{nodeReduxState || "-"}</pre>
           </div>
         </Modal>

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -26,16 +26,17 @@ const Wrapper = styled.div`
 
   .modal .info-row {
     display: flex;
-    justify-content: space-between;
     margin: 5px 0;
 
     .title {
       width: 60px;
+      min-width: 60px;
       font-weight: 700;
     }
 
     .description {
-      width: 135px;
+      width: auto;
+      min-width: 130px;
       text-align: left;
     }
   }
@@ -86,16 +87,16 @@ export default function D3Tree() {
         if (typeof nodeData.data.name === "object") setNodeName("-");
 
         setNodeId(nodeData.data.uuid);
-        setNodeProps(nodeData.data.props.join(", "));
-        setNodeState(nodeData.data.state.join(", "));
+        setNodeProps(nodeData.data.props.join(",\n"));
+        setNodeState(nodeData.data.state.join(",\n"));
       }
     });
     svgElement.addEventListener("mousemove", event => {
       const isMouseCloseToRight =
-        window.innerWidth - event.clientX < SIZE.MODAL_WIDTH + SIZE.PADDING;
+        window.innerWidth - event.clientX < modal.clientWidth + SIZE.PADDING;
 
       if (isMouseCloseToRight) {
-        modal.style.left = `${event.clientX - 10 - SIZE.MODAL_WIDTH}px`;
+        modal.style.left = `${event.clientX - 10 - modal.clientWidth}px`;
         modal.style.top = `${event.clientY - modal.clientHeight - 10}px`;
       } else {
         modal.style.left = `${event.clientX + 10}px`;
@@ -121,11 +122,11 @@ export default function D3Tree() {
           </div>
           <div className="info-row">
             <span className="title">props : </span>
-            <span className="description">{nodeProps || "-"}</span>
+            <pre className="description">{nodeProps || "-"}</pre>
           </div>
           <div className="info-row">
             <span className="title">state : </span>
-            <span className="description">{nodeState || "-"}</span>
+            <pre className="description">{nodeState || "-"}</pre>
           </div>
         </Modal>
       </div>

--- a/src/components/D3tree.js
+++ b/src/components/D3tree.js
@@ -23,6 +23,22 @@ const Wrapper = styled.div`
     color: ${COLORS.BUTTON};
     position: absolute;
   }
+
+  .modal .info-row {
+    display: flex;
+    justify-content: space-between;
+    margin: 5px 0;
+
+    .title {
+      width: 60px;
+      font-weight: 700;
+    }
+
+    .description {
+      width: 135px;
+      text-align: left;
+    }
+  }
 `;
 
 export default function D3Tree() {
@@ -92,9 +108,18 @@ export default function D3Tree() {
       <div ref={svg} className="svg" />
       <div className="modal">
         <Modal nodeId={nodeId}>
-          <div>name: {nodeName || "-"}</div>
-          <div>props: {nodeProps || "-"}</div>
-          <div>state: {nodeState || "-"}</div>
+          <div className="info-row">
+            <span className="title">name : </span>
+            <span className="description">{nodeName || "-"}</span>
+          </div>
+          <div className="info-row">
+            <span className="title">props : </span>
+            <span className="description">{nodeProps || "-"}</span>
+          </div>
+          <div className="info-row">
+            <span className="title">state : </span>
+            <span className="description">{nodeState || "-"}</span>
+          </div>
         </Modal>
       </div>
     </Wrapper>

--- a/src/components/DirectorySelection.js
+++ b/src/components/DirectorySelection.js
@@ -1,0 +1,71 @@
+import { useDispatch, useSelector } from "react-redux";
+import { useEffect } from "react";
+import styled from "styled-components";
+import { setDirectoryPath } from "../features/pathSlice";
+import { SIZE, COLORS } from "../assets/constants";
+
+const ButtonSection = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  width: 50%;
+
+  .button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    > p {
+      padding-bottom: ${SIZE.PADDING}px;
+    }
+  }
+`;
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 250px;
+  height: 30px;
+  background-color: ${COLORS.WHITE};
+  border: 2px solid ${COLORS.BUTTON};
+  border-radius: 10px;
+  color: ${COLORS.BUTTON};
+  font-weight: 500;
+  transition: 0.3s all ease;
+
+  :hover {
+    cursor: pointer;
+    background-color: ${COLORS.BUTTON};
+    color: ${COLORS.WHITE};
+  }
+`;
+
+export default function DirectorySelection() {
+  const dispatch = useDispatch();
+  const { directoryPath } = useSelector(state => state.path);
+  let pathEllips = directoryPath || "폴더 선택";
+
+  if (directoryPath) {
+    pathEllips =
+      directoryPath.length > 50
+        ? `...${directoryPath.slice(-50)}`
+        : directoryPath;
+  }
+
+  useEffect(() => {
+    window.electronAPI.sendFilePath((event, path) => {
+      dispatch(setDirectoryPath({ path }));
+    });
+  }, [directoryPath, dispatch]);
+
+  return (
+    <ButtonSection>
+      <div className="button">
+        <p>프로젝트의 폴더를 선택해주세요.</p>
+        <Button id="directoryButton" data-testid="path">
+          {pathEllips}
+        </Button>
+      </div>
+    </ButtonSection>
+  );
+}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -4,7 +4,8 @@ import { COLORS, SIZE } from "../assets/constants";
 
 const Wrapper = styled.div`
   display: ${props => (props.nodeId ? "block" : "none")};
-  width: ${SIZE.MODAL_WIDTH}px;
+  width: auto;
+  min-width: ${SIZE.MODAL_WIDTH}px;
   padding: ${SIZE.PADDING / 2}px ${SIZE.PADDING}px;
   background-color: ${COLORS.BORDER};
   border: 1px solid ${COLORS.BUTTON};

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
   border: 1px solid ${COLORS.BUTTON};
   border-radius: 4px;
   color: ${COLORS.WHITE};
-  box-shadow: 0px 1px 5px 1px rgba(255, 255, 255, 0.2);
+  box-shadow: 1px 1px 5px 1px rgba(255, 255, 255, 0.2);
   font-family: "Whitney", "Helvetica Neue";
   transition: all 0.3s ease;
 `;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -4,7 +4,7 @@ import { COLORS, SIZE } from "../assets/constants";
 
 const Wrapper = styled.div`
   display: ${props => (props.nodeId ? "block" : "none")};
-  width: 200px;
+  width: ${SIZE.MODAL_WIDTH}px;
   padding: ${SIZE.PADDING / 2}px ${SIZE.PADDING}px;
   background-color: ${COLORS.BORDER};
   border: 1px solid ${COLORS.BUTTON};

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -4,8 +4,8 @@ import { COLORS, SIZE } from "../assets/constants";
 
 const Wrapper = styled.div`
   display: ${props => (props.nodeId ? "block" : "none")};
-  width: 180px;
-  padding: ${SIZE.PADDING}px;
+  width: 200px;
+  padding: ${SIZE.PADDING / 2}px ${SIZE.PADDING}px;
   background-color: ${COLORS.BORDER};
   border: 1px solid ${COLORS.BUTTON};
   border-radius: 4px;

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,0 +1,73 @@
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+import { SIZE } from "../assets/constants";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  width: 50%;
+
+  .sliderSection {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    width: 100%;
+
+    .slider {
+      display: flex;
+      flex-direction: column;
+      width: 20vw;
+
+      .title {
+        text-align: center;
+      }
+    }
+  }
+
+  .guideSection {
+    padding: ${SIZE.PADDING}px;
+    text-align: center;
+    align-items: center;
+  }
+`;
+
+export default function Slider() {
+  const { directoryPath } = useSelector(state => state.path);
+
+  return (
+    <Wrapper>
+      <div className="sliderSection">
+        <div className="slider">
+          <div className="title">WIDTH</div>
+          <input
+            id="sliderX"
+            type="range"
+            min="10"
+            max="700"
+            defaultValue={window.innerWidth / 4.5}
+            name="width"
+            aria-label="width"
+          />
+        </div>
+        <div className="slider">
+          <div className="title">HEIGHT</div>
+          <input
+            id="sliderY"
+            type="range"
+            min="10"
+            max="400"
+            name="height"
+            aria-label="height"
+          />
+        </div>
+      </div>
+      {!directoryPath && (
+        <div className="guideSection">
+          폴더 경로를 선택하면 아래 예시와 같이 트리구조가 렌더링 됩니다.
+        </div>
+      )}
+    </Wrapper>
+  );
+}

--- a/src/features/d3treeSlice.js
+++ b/src/features/d3treeSlice.js
@@ -2,8 +2,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  widthSpacing: 150,
-  heightSpacing: 250,
   layoutWidth: 700,
   layoutHeight: 1100,
 };
@@ -15,12 +13,6 @@ const d3treeSlice = createSlice({
     setLayout(state, action) {
       state.layoutWidth = action.payload.clientWidth;
       state.layoutHeight = action.payload.clientHeight;
-    },
-    setWidthSpacing(state, action) {
-      state.widthSpacing = action.payload.width;
-    },
-    setHeightSpacing(state, action) {
-      state.heightSpacing = action.payload.height;
     },
   },
 });

--- a/src/features/pathSlice.js
+++ b/src/features/pathSlice.js
@@ -2,7 +2,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  hasPath: false,
   directoryPath: null,
 };
 
@@ -10,14 +9,11 @@ const pathSlice = createSlice({
   name: "path",
   initialState,
   reducers: {
-    checkPath(state) {
-      state.hasPath = true;
-    },
     setDirectoryPath(state, action) {
       state.directoryPath = action.payload.path;
     },
   },
 });
 
-export const pathActions = pathSlice.actions;
+export const { setDirectoryPath } = pathSlice.actions;
 export default pathSlice.reducer;

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -30,6 +30,7 @@ Node.prototype.addChild = function (child) {
 
 Node.prototype.setName = function (node) {
   this.tag = node.tag;
+  this.file = node._debugSource;
 
   if (node.tag === 0) {
     this.name = node.elementType.name;
@@ -39,14 +40,6 @@ Node.prototype.setName = function (node) {
     this.name = node.memoizedProps;
   } else if (node.tag === 8) {
     this.name = "React.StrictMode";
-  } else if (node.tag === 10) {
-    this.name = node.elementType.name;
-  } else if (node.tag === 11) {
-    if (node.child.elementType === "a") {
-      this.name = "Link";
-    } else if (node.child.tag === 5) {
-      this.name = "Styled component";
-    }
   } else if (node.tag === 15) {
     this.name = "SimpleMemoComponent";
   } else {
@@ -59,11 +52,6 @@ Node.prototype.addProps = function (node) {
 
   if (node.tag === 0 || node.tag === 1) {
     Object.values(node.memoizedProps).forEach(item => this.props.push(item));
-  }
-
-  if (node.tag === 11 && node.child.elementType === "a") {
-    const linkHref = node.memoizedProps.to;
-    this.props.push(`to "${linkHref}"`);
   }
 };
 

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -14,7 +14,7 @@ const pushState = function (memoizedState, stateArray, reduxStateArray) {
   if (memoizedState === null) return;
 
   if (memoizedState.baseState) {
-    stateArray.push(memoizedState.baseState);
+    stateArray.push(JSON.stringify(memoizedState.baseState));
   }
 
   if (memoizedState.queue?.value) {
@@ -29,6 +29,8 @@ Node.prototype.addChild = function (child) {
 };
 
 Node.prototype.setName = function (node) {
+  this.tag = node.tag;
+
   if (node.tag === 0) {
     this.name = node.elementType.name;
   } else if (node.tag === 3) {
@@ -37,10 +39,14 @@ Node.prototype.setName = function (node) {
     this.name = node.memoizedProps;
   } else if (node.tag === 8) {
     this.name = "React.StrictMode";
-  } else if (node.tag === 10 && node.elementType) {
-    this.name = node.elementType._context.displayName;
-  } else if (node.tag === 11 && node.elementType) {
-    this.name = node.elementType.target;
+  } else if (node.tag === 10) {
+    this.name = node.elementType.name;
+  } else if (node.tag === 11) {
+    if (node.child.elementType === "a") {
+      this.name = "Link";
+    } else if (node.child.tag === 5) {
+      this.name = "Styled component";
+    }
   } else if (node.tag === 15) {
     this.name = "SimpleMemoComponent";
   } else {
@@ -53,6 +59,11 @@ Node.prototype.addProps = function (node) {
 
   if (node.tag === 0 || node.tag === 1) {
     Object.values(node.memoizedProps).forEach(item => this.props.push(item));
+  }
+
+  if (node.tag === 11 && node.child.elementType === "a") {
+    const linkHref = node.memoizedProps.to;
+    this.props.push(`to "${linkHref}"`);
   }
 };
 

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -10,11 +10,16 @@ function Node() {
 }
 
 const pushState = function (memoizedState, stateArray) {
-  if (!memoizedState) return;
+  if (memoizedState === null) return;
 
-  if (typeof memoizedState.memoizedState === "object") return;
+  if (memoizedState.baseState) {
+    stateArray.push(memoizedState.baseState);
+  }
 
-  stateArray.push(memoizedState.memoizedState);
+  if (memoizedState.queue?.value) {
+    stateArray.push(JSON.stringify(memoizedState.queue.value, null, 2));
+  }
+
   pushState(memoizedState.next, stateArray);
 };
 

--- a/src/utils/Node.js
+++ b/src/utils/Node.js
@@ -5,11 +5,12 @@ function Node() {
   this.name = "";
   this.props = [];
   this.state = [];
+  this.reduxState = [];
   this.uuid = uuidv4();
   this.children = [];
 }
 
-const pushState = function (memoizedState, stateArray) {
+const pushState = function (memoizedState, stateArray, reduxStateArray) {
   if (memoizedState === null) return;
 
   if (memoizedState.baseState) {
@@ -17,10 +18,10 @@ const pushState = function (memoizedState, stateArray) {
   }
 
   if (memoizedState.queue?.value) {
-    stateArray.push(JSON.stringify(memoizedState.queue.value, null, 2));
+    reduxStateArray.push(JSON.stringify(memoizedState.queue.value, null, 2));
   }
 
-  pushState(memoizedState.next, stateArray);
+  pushState(memoizedState.next, stateArray, reduxStateArray);
 };
 
 Node.prototype.addChild = function (child) {
@@ -59,7 +60,7 @@ Node.prototype.addState = function (node) {
   if (!node.memoizedState) return;
 
   if (node.tag === 0 || node.tag === 1) {
-    pushState(node.memoizedState, this.state);
+    pushState(node.memoizedState, this.state, this.reduxState);
   }
 };
 

--- a/src/utils/getTreeSVG.js
+++ b/src/utils/getTreeSVG.js
@@ -19,14 +19,6 @@ export default function getTreeSVG(
     height,
     r = 10,
     padding = 0.01,
-    fill = "#999",
-    stroke = "#666666",
-    strokeWidth = 3,
-    strokeOpacity = 5,
-    strokeLinejoin,
-    strokeLinecap,
-    halo = "#fff",
-    haloWidth = 4,
     curve = curveBumpX,
   } = {},
 ) {
@@ -87,11 +79,9 @@ export default function getTreeSVG(
     svg
       .append("g")
       .attr("fill", "none")
-      .attr("stroke", stroke)
-      .attr("stroke-opacity", strokeOpacity)
-      .attr("stroke-linecap", strokeLinecap)
-      .attr("stroke-linejoin", strokeLinejoin)
-      .attr("stroke-width", strokeWidth)
+      .attr("stroke", "#666666")
+      .attr("stroke-opacity", 5)
+      .attr("stroke-width", 3)
       .selectAll("path")
       .data(root.links())
       .join("path")
@@ -112,7 +102,7 @@ export default function getTreeSVG(
     node
       .append("circle")
       .attr("id", d => d.data.uuid)
-      .attr("fill", d => (d.children ? stroke : fill))
+      .attr("fill", d => (d.data.tag === 0 ? "#7289da" : "#999"))
       .attr("r", r);
 
     if (labelList)
@@ -121,8 +111,8 @@ export default function getTreeSVG(
         .attr("dy", `${labelY}em`)
         .attr("text-anchor", "middle")
         .attr("paint-order", "stroke")
-        .attr("stroke", halo)
-        .attr("stroke-width", haloWidth)
+        .attr("stroke", "#fff")
+        .attr("stroke-width", 4)
         .text((d, i) => labelList[i]);
 
     svg.call(

--- a/src/utils/reactFiberTree.js
+++ b/src/utils/reactFiberTree.js
@@ -16,7 +16,12 @@ function createNode(fiberNode, tree, parentTree) {
 
   if (fiberNode.child) {
     tree.addChild(new Node());
-    createNode(fiberNode.child, tree.children[0], tree);
+
+    if (fiberNode.child.tag === 10 || fiberNode.child.tag === 11) {
+      createNode(fiberNode.child.child, tree.children[0], tree);
+    } else {
+      createNode(fiberNode.child, tree.children[0], tree);
+    }
   }
 }
 

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -1,5 +1,7 @@
 import deepCopy from "./deepCopy";
 
+const essentialKeys = ["memoizedState", "queue", "value"];
+
 const seen = new WeakSet();
 
 const getCircularReplacer = (key, value) => {
@@ -8,6 +10,8 @@ const getCircularReplacer = (key, value) => {
 
   if (key === "memoizedProps" && typeof value === "object" && value)
     return value;
+
+  if (essentialKeys.includes(key)) return value;
 
   if (typeof value === "object" && value !== null) {
     if (seen.has(value)) return undefined;

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable no-prototype-builtins */
 import deepCopy from "./deepCopy";
 
 const essentialKeys = ["memoizedState", "queue", "value"];
@@ -9,15 +7,6 @@ const seen = new WeakSet();
 const getCircularReplacer = (key, value) => {
   if (key === "elementType" && typeof value === "function")
     return { name: value.name };
-
-  if (
-    key === "elementType" &&
-    typeof value === "object" &&
-    value &&
-    value.hasOwnProperty("_context")
-  ) {
-    return { name: value._context.displayName };
-  }
 
   if (key === "memoizedProps" && typeof value === "object" && value)
     return value;

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -19,25 +19,21 @@ const getCircularReplacer = (key, value) => {
 };
 
 const reactree = rootInternalRoot => {
-  try {
-    const fiber = deepCopy(rootInternalRoot);
-    const fiberJson = JSON.stringify(fiber.current, getCircularReplacer);
-    const blob = new Blob([fiberJson], { type: "text/json;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
+  const fiber = deepCopy(rootInternalRoot);
+  const fiberJson = JSON.stringify(fiber.current, getCircularReplacer);
+  const blob = new Blob([fiberJson], { type: "text/json;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
 
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "data.json";
-    link.click();
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "data.json";
+  link.click();
 
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 0);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
 
-    return undefined;
-  } catch (error) {
-    return console.error(error);
-  }
+  return undefined;
 };
 
 export default reactree;

--- a/src/utils/reactree.js
+++ b/src/utils/reactree.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-prototype-builtins */
 import deepCopy from "./deepCopy";
 
 const essentialKeys = ["memoizedState", "queue", "value"];
@@ -7,6 +9,15 @@ const seen = new WeakSet();
 const getCircularReplacer = (key, value) => {
   if (key === "elementType" && typeof value === "function")
     return { name: value.name };
+
+  if (
+    key === "elementType" &&
+    typeof value === "object" &&
+    value &&
+    value.hasOwnProperty("_context")
+  ) {
+    return { name: value._context.displayName };
+  }
 
   if (key === "memoizedProps" && typeof value === "object" && value)
     return value;
@@ -23,21 +34,25 @@ const getCircularReplacer = (key, value) => {
 };
 
 const reactree = rootInternalRoot => {
-  const fiber = deepCopy(rootInternalRoot);
-  const fiberJson = JSON.stringify(fiber.current, getCircularReplacer);
-  const blob = new Blob([fiberJson], { type: "text/json;charset=utf-8" });
-  const url = URL.createObjectURL(blob);
+  try {
+    const fiber = deepCopy(rootInternalRoot);
+    const fiberJson = JSON.stringify(fiber.current, getCircularReplacer);
+    const blob = new Blob([fiberJson], { type: "text/json;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
 
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = "data.json";
-  link.click();
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "data.json";
+    link.click();
 
-  setTimeout(() => {
-    URL.revokeObjectURL(url);
-  }, 0);
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 0);
 
-  return undefined;
+    return undefined;
+  } catch (error) {
+    return console.error(error);
+  }
 };
 
 export default reactree;


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 작업 브랜치 생성 전에 local dev를 최신화했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 모달창 내부 css를 수정해서 카테고리별로 정보가 정리되어서 보이도록 했습니다.
- window 가로와 모달창 가로 길이에 따라서 커서 오른쪽에 보이던 모달창이 안 보일 정도로 마우스가 오른쪽에 가까워지면 모달창이 왼쪽에서 보이도록 했습니다. (반응형)
- `local state`와 `redux state`를 구별해서 보여줍니다.
- `App.js`에서 폴더선택버튼 및 슬라이더 관련 코드는 따로 컴포넌트로 분리했습니다.
- 트리 구조에서 각 노드를 클릭할 때, 각 노드의 컴포넌트 또는 엘리먼트가 선언된 파일 경로가 아래에 보이도록 했습니다. 이는 추후에 electron main process와 연결해서 해당파일의 코드를 읽어올 수 있을 것 같습니다.

## 추가 설명
- `props`나 `state`들이 각각 줄바꿈되어서 보이도록 하기 위해서 `<pre>`태그 내에 작성했습니다.
- UX 개선을 위해서 슬라이더 가로 길이를 늘렸습니다. 슬라이더바가 길어지면 사용자가 좀 더 섬세하게 트리구조 width height를 조절할 수 있습니다.
- 모달창은 `nodeId` 존재 여부에 따라서만 보이거나 안 보이므로, `setNodeId(null)` 외에 나머지는 삭제했습니다.
- `reactree.js`에서 순환참조 삭제과정에서 일부 key값이 누락됐습니다. 필요한 key값들은 배열 `essentialKeys`로 선언해서 누락되지 않도록 했습니다. 이 부분 로직은 좀 더 생각해봐야 할 것 같습니다.

## 비고
- 모달창 css수정 결과입니다.
![스크린샷 2023-03-28 오전 11 22 11](https://user-images.githubusercontent.com/50537876/228230144-21bdf73e-3da9-4dea-b85c-bcdcadecd7d8.png)
