### PR TITLE
Feature/트리노드클릭이벤트추가

### DIFF
--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -23,7 +23,7 @@ app.whenReady().then(() => {
   ipcMain.handle("open-dialog", openDialogHandler);
 
   ipcMain.handle("nodeFileInfo-to-main", (event, value) => {
-    const nodeFilePath = value.fileName;
+    const nodeFilePath = value?.fileName;
     const code = readFileSync(nodeFilePath, { encoding: "utf8" });
 
     const mainWindow = BrowserWindow.getFocusedWindow();

--- a/public/Electron/main.js
+++ b/public/Electron/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow, ipcMain, globalShortcut } = require("electron");
 const path = require("path");
+const { readFileSync } = require("fs");
 
 const { quitApplication } = require("./utils");
 const { openDialogHandler } = require("./ipc-handler");
@@ -20,6 +21,14 @@ const createWindow = () => {
 app.whenReady().then(() => {
   createWindow();
   ipcMain.handle("open-dialog", openDialogHandler);
+
+  ipcMain.handle("nodeFileInfo-to-main", (event, value) => {
+    const nodeFilePath = value.fileName;
+    const code = readFileSync(nodeFilePath, { encoding: "utf8" });
+
+    const mainWindow = BrowserWindow.getFocusedWindow();
+    mainWindow.webContents.send("nodeFileInfo-to-react", code);
+  });
 
   if (process.platform === "darwin") {
     globalShortcut.register("Command+Q", quitApplication);

--- a/public/Electron/preload.js
+++ b/public/Electron/preload.js
@@ -4,4 +4,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   openDialog: () => ipcRenderer.invoke("open-dialog"),
   getFilePath: callback => ipcRenderer.on("path-to-react", callback),
   getNodeData: callback => ipcRenderer.on("node-to-react", callback),
+  sendNodeFileInfo: fileInfo =>
+    ipcRenderer.invoke("nodeFileInfo-to-main", fileInfo),
+  getNodeFileInfo: fileInfo =>
+    ipcRenderer.on("nodeFileInfo-to-react", fileInfo),
 });

--- a/src/components/DirectorySelection.js
+++ b/src/components/DirectorySelection.js
@@ -53,7 +53,7 @@ export default function DirectorySelection() {
   }
 
   useEffect(() => {
-    window.electronAPI.sendFilePath((event, path) => {
+    window.electronAPI.getFilePath((event, path) => {
       dispatch(setDirectoryPath({ path }));
     });
   }, [directoryPath, dispatch]);


### PR DESCRIPTION
## PR 전 확인사항
 - [x] 작업 브랜치 생성 전에 local dev를 최신화했습니다.
 - [x] base 브랜치명을 확인했습니다.
 - [x] 코드 컨벤션을 모두 지켰습니다.

## 작업 사항
- 트리구조 아래에 코드 컨테이너가 있습니다.
- 트리구조에서 각 노드를 클릭하면 `electronAPI`를 통해서 main process에 클릭한 노드에 대한 정보가 전송됩니다.
- main process에서 노드 정보를 받아서 파일 경로를 변수로 저장합니다. 이 파일 경로를 바탕으로 코드 문자열을 읽고 이 문자열을 `<D3tree />`로 전송합니다.
-  `<D3tree />`에서 문자열을 받아서 해당 컴포넌트 또는 엘리먼트가 선언된 파일의 코드를 컨테이너에서 렌더링해줍니다.

## 추가 설명
- `node._debugSource`에서 해당 컴포넌트 또는 엘리먼트가 선언된 파일 경로와 선언된 위치가 보입니다.
- `<pre />`를 통해서 코드의 공백과 줄바꿈을 유지해서 나타냅니다. 그런데 이는 추후에 code mirror와 같은 툴을 이용해서 시각화할 수 있을 것 같습니다.

## 비고
- 